### PR TITLE
Read utf8 files on Python 3

### DIFF
--- a/make_stub_files.py
+++ b/make_stub_files.py
@@ -960,8 +960,12 @@ class Controller:
             return
         # Set g_input_file_name for error messages.
         g_input_file_name = g.shortFileName(fn)
-        with open(fn, 'r') as f:
-            s = f.read()
+        try:
+            with open(fn, 'r') as f:
+                s = f.read()
+        except UnicodeDecodeError:  # Python 3 only, try utf-8 encoding.
+            with open(fn, 'r', encoding='utf-8') as f:
+                s = f.read()
         #
         # Compute the output file name.
         if self.output_directory:


### PR DESCRIPTION
On python 3 the script failed to read input files that are encoded in UTF-8 (and contain non-ascii characters)